### PR TITLE
解决Windows环境下zk路径错误

### DIFF
--- a/handler/config/znode.py
+++ b/handler/config/znode.py
@@ -307,7 +307,8 @@ class ZdZnodeSaveHandler(CommonBaseHandler):
         zk_path = ""
         if not self.path:
             # 新增节点需要进行存在检验
-            zk_path = os.path.join(self.parent_path, self.node_name)
+            zk_path = "/{0}".format(self.node_name) if self.parent_path == "/" else "{0}/{1}".format(self.parent_path,
+                                                                                                     self.node_name)
             if ZookeeperService.exists(self.cluster_name, zk_path):
                 return self.ajax_popup(code=300, msg="节点已经存在！")
         else:

--- a/service/snapshot.py
+++ b/service/snapshot.py
@@ -171,7 +171,7 @@ def _get_recursively(zoo_client, path, nodes):
     else:
         nodes.append({"path": path, "data": data})
         for child in zoo_client.get_children(path):
-            child_path = os.path.join(path, child)
+            child_path = "/{0}".format(child) if path == "/" else "{0}/{1}".format(path, child)
             _get_recursively(zoo_client, child_path, nodes)
 
 

--- a/service/znode.py
+++ b/service/znode.py
@@ -38,7 +38,7 @@ def get_child_znodes(cluster_name, path):
     children = zoo_client.get_children(path)
     # iter child nodes and convert to dict with extra info
     for child in children:
-        child_path = os.path.join(path, child)
+        child_path = "/{0}".format(child) if path == "/" else "{0}/{1}".format(path, child)
         data, _ = zoo_client.get(child_path)
         # node
         node = {"path": child_path, "value": data}
@@ -74,7 +74,7 @@ def set_batch_znodes(cluster_name, parent_path, batch_data, business=''):
     """set batch znodes from python data
     """
     for key, data in batch_data:
-        path = os.path.join(parent_path, key)
+        path = "/{0}".format(key) if parent_path == "/" else "{0}/{1}".format(parent_path, key)
         set_znode(cluster_name, path, data, business=business)
 
 
@@ -115,7 +115,7 @@ def delete_znodes_diff_with_keys(cluster_name, parent_path, keys):
     children = zoo_client.get_children(parent_path)
     diff_znodes = [child for child in children if child not in keys]
     for znode in diff_znodes:
-        path = os.path.join(parent_path, znode)
+        path = "/{0}".format(znode) if parent_path == "/" else "{0}/{1}".format(parent_path, znode)
         zoo_client.delete(path, version=-1, recursive=False)
         delete_znodes(cluster_name, path, recursive=False, del_snapshots=True)
 
@@ -142,7 +142,7 @@ def get_znode_tree(zoo_client, path, nodes, current_id='1', parent_id='0'):
             idx = '{0:02d}'.format(idx)
             # parent_id as 1, then child_id should be 10, 11, 12...
             child_id = "{0}{1}".format(current_id, idx)
-            child_path = os.path.join(path, child)
+            child_path = "/{0}".format(child) if path == "/" else "{0}/{1}".format(path, child)
             get_znode_tree(zoo_client, child_path, nodes, child_id, current_id)
 
 

--- a/static/BJUI/js/bjui-tabledit.js
+++ b/static/BJUI/js/bjui-tabledit.js
@@ -127,6 +127,8 @@
                             $th = $(this), $child = $th.children(), $pic = $th.find('.pic-box')
                         
                         if (typeof val == 'undefined') val = $td.html()
+                        if (typeof val == 'object') val = JSON.stringify(val)
+
                         if (!$td.data('noedit')) {
                             if ($child.length) {
                                 if ($child.is('input:checkbox') || $child.is('input:radio')) {


### PR DESCRIPTION
解决了Windows环境下分隔符为 \ 导致zk节点路径拼接错误，导致数据获取操作异常的问题。生产环境下存在zk部署在Linux，但管理平台部署在Windows的可能